### PR TITLE
Allow custom config path

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,17 +22,22 @@ python mgym_GymRun.py train --num_episodes 10
 --num_episodes: Sets the number of training episodes.  
 The RL algorithm is selected internally in the mgym_GymRun.py code.
 
-3. **To run a classical scheduler (e.g., random scheduling), use:**  
-python mgym_DefSchdRun.py --num_episodes 10 --algo_choice 1  
---num_episodes: Number of episodes to simulate.  
---algo_choice: Selects the scheduler algorithm as defined in scheduler.py.  
+3. **To run a classical scheduler (e.g., random scheduling), use:**
+python mgym_DefSchdRun.py --num_episodes 10 --algo_choice 1
+--num_episodes: Number of episodes to simulate.
+--algo_choice: Selects the scheduler algorithm as defined in scheduler.py.
 Example: 1 stands for random scheduling.
 
-4. **To play using a pretrained model, run:**  
-python mgym_GymRun.py play --num_episodes 5 --model_path <path_to_saved_model.zip>  
+4. **To play using a pretrained model, run:**
+python mgym_GymRun.py play --num_episodes 5 --model_path <path_to_saved_model.zip>
 Replace <path_to_saved_model.zip> with the actual path to your saved model.
 
-5. **To change configuration data:**  
-You can modify the simulation settings by editing the config.extend.txt file. This allows you to adjust parameters such as environment details, scheduler settings, and other simulation-related options.
+5. **Use a custom configuration file (optional):**
+Both `mGym_GymRun.py` and `mGym_DefSchdRun.py` accept a `--config` argument to load parameters from an alternative file.
+Example: `python mGym_GymRun.py train --num_episodes 10 --config my_config.txt`
+Example: `python mGym_DefSchdRun.py --num_episodes 5 --algo_choice 1 --config my_config.txt`
+
+6. **To change configuration data:**
+You can modify the simulation settings by editing the config.extend.txt file or another file provided via `--config`. This allows you to adjust parameters such as environment details, scheduler settings, and other simulation-related options.
 
 

--- a/mGym_DefSchdRun.py
+++ b/mGym_DefSchdRun.py
@@ -41,21 +41,23 @@ def gen_seed(iteration, initial_seed=None, ax=1664525, cx=1013904223, mx=2**32):
 parser = argparse.ArgumentParser(description="Run the simulation with specified number of iterations and algorithm choice.")
 parser.add_argument('--num_episodes', type=int, default=10, help="Number of episodes to run the simulation")
 parser.add_argument('--algo_choice', type=int, required=True, help="Choice of scheduling algorithm (integer only)")
+parser.add_argument('--config', type=str, default='config_extend.txt', help="Path to configuration file")
 
 args = parser.parse_args()
 
 # Get the number of iterations and algorithm choice from command line arguments
 iter = args.num_episodes
 algo_choice = args.algo_choice
+config_path = args.config
 
 # Array to store KPI values for each iteration
 arr = []
 
 # Run the simulation for the specified number of iterations
 for epsd in range(iter):
- 
+
     # Run the simulation with the specified parameters
-    kpi_01 = denv.runDes(fsim=False, flag_RL_sched=False, fdef_schdlr_choice=algo_choice)
+    kpi_01 = denv.runDes(fsim=False, flag_RL_sched=False, fdef_schdlr_choice=algo_choice, config_file=config_path)
     print(f"Value of KPI01-PVol: {kpi_01}")
     # Append the result to the list
     arr.append(kpi_01)

--- a/mGym_GymEnv.py
+++ b/mGym_GymEnv.py
@@ -23,13 +23,14 @@ from gymnasium.envs.registration import register
 class Minegym(Env):
     metadata = {"render_modes": ["console"]}
 
-    def __init__(self, render_mode="console"):
+    def __init__(self, render_mode="console", config_file="config_extend.txt"):
         super(Minegym, self).__init__()
 
         self.render_mode = render_mode
+        self.config_file = config_file
 
         # Load configuration values
-        cfg_samplr = ConfigSampler('config_extend.txt')  # Load from configuration file.** NO seed needed since no distribution sample
+        cfg_samplr = ConfigSampler(self.config_file)  # Load from configuration file.** NO seed needed since no distribution sample
         #cfg_samplr = ConfigSampler('config_extend.txt', time_scale=5.0)
         self.NumTrucks = cfg_samplr.get_sampled_value('TR')
         self.NumShovels = cfg_samplr.get_sampled_value('SH')
@@ -125,7 +126,7 @@ class Minegym(Env):
 
                 # Start a new DES process
                 print(f"Starting a new DES process with fsim: {fsim}")
-                self.des_process = multiprocessing.Process(target=des_main, args=(fsim,))
+                self.des_process = multiprocessing.Process(target=des_main, args=(fsim,), kwargs={'config_file': self.config_file})
                 self.des_process.start()
                 print("DES process started.")
 

--- a/mGym_GymRun.py
+++ b/mGym_GymRun.py
@@ -18,12 +18,13 @@ from typing import Optional
 
 # Will be set in main()
 
-def register_minegym():
+def register_minegym(config_file: str = 'config_extend.txt'):
     """Register the Minegym environment with Gymnasium."""
     try:
         register(
             id='Minegym-v0',
             entry_point='mGym_GymEnv:Minegym',
+            kwargs={'config_file': config_file}
         )
         print("Environment registered successfully!")
     except Exception as e:
@@ -139,7 +140,7 @@ class TrainingLoggerCallback(BaseCallback):
         if hasattr(self, 'log_file_handle'):
             self.log_file_handle.close()
 
-def main(choice, num_episodes, model_path=None):
+def main(choice, num_episodes, model_path=None, config_file='config_extend.txt'):
     """
     Main function to either train a new model or play with an existing one.
     
@@ -156,8 +157,8 @@ def main(choice, num_episodes, model_path=None):
         MODEL_SAVE_DIR = f"saved_models_{timestamp}"
         os.makedirs(MODEL_SAVE_DIR, exist_ok=True)
         print(f"Created model directory: {MODEL_SAVE_DIR}")
-    register_minegym()
-    env = gym.make("Minegym-v0", render_mode="console")
+    register_minegym(config_file)
+    env = gym.make("Minegym-v0", render_mode="console", config_file=config_file)
 
     if choice == 'train':
         # Initialize the PPO model with the same hyperparameters
@@ -245,7 +246,13 @@ if __name__ == "__main__":
         '--model_path',
         type=str,
         help="Path to the pre-trained model for playing. Required for 'play'."
-)
-    
+    )
+    parser.add_argument(
+        '--config',
+        type=str,
+        default='config_extend.txt',
+        help='Path to configuration file'
+    )
+
     args = parser.parse_args()
-    main(args.choice, args.num_episodes, args.model_path)
+    main(args.choice, args.num_episodes, args.model_path, args.config)


### PR DESCRIPTION
## Summary
- enable passing custom config file to Minegym environment and DES simulator
- allow specifying `--config` in CLI scripts
- document config path option in README

## Testing
- `python -m py_compile mGym_GymEnv.py mGym_DesEnv.py mGym_GymRun.py mGym_DefSchdRun.py read_config.py`

------
https://chatgpt.com/codex/tasks/task_e_68437daea74c832cb5dbf34abbc7f332