### PR TITLE
Add render option to mgym run

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,4 +54,8 @@ You can modify the simulation settings by editing the config.extend.txt file or 
 7. **Progress Bars**
 Both training (`mGym_GymRun.py`) and classical scheduler runs (`mGym_DefSchdRun.py`) display an episode progress bar powered by `tqdm`. The package is included in `requirements.txt` (and in `environment.yml` for conda users).
 
+8. **Human Rendering (optional)**
+To view the environment in graphical "human" mode, add `--render human` when running `mGym_GymRun.py`:
+`python mGym_GymRun.py play --num_episodes 1 --model_path <path_to_saved_model.zip> --render human`
+
 

--- a/mGym_GymRun.py
+++ b/mGym_GymRun.py
@@ -145,7 +145,7 @@ class TrainingLoggerCallback(BaseCallback):
         if hasattr(self, 'log_file_handle'):
             self.log_file_handle.close()
 
-def main(choice, num_episodes, model_path=None, config_file='config_extend.txt'):
+def main(choice, num_episodes, model_path=None, config_file='config_extend.txt', render_mode='console'):
     """
     Main function to either train a new model or play with an existing one.
     
@@ -163,7 +163,7 @@ def main(choice, num_episodes, model_path=None, config_file='config_extend.txt')
         os.makedirs(MODEL_SAVE_DIR, exist_ok=True)
         print(f"Created model directory: {MODEL_SAVE_DIR}")
     register_minegym(config_file)
-    env = gym.make("Minegym-v0", render_mode="console", config_file=config_file)
+    env = gym.make("Minegym-v0", render_mode=render_mode, config_file=config_file)
 
     if choice == 'train':
         # Initialize the PPO model with the same hyperparameters
@@ -257,6 +257,12 @@ if __name__ == "__main__":
         default='config_extend.txt',
         help='Path to configuration file'
     )
+    parser.add_argument(
+        '--render',
+        type=str,
+        default='console',
+        help="Render mode to pass to gym.make (e.g., 'human' or 'console')."
+    )
 
     args = parser.parse_args()
-    main(args.choice, args.num_episodes, args.model_path, args.config)
+    main(args.choice, args.num_episodes, args.model_path, args.config, args.render)


### PR DESCRIPTION
## Summary
- expose render mode in `mGym_GymRun.py`
- pass render mode into `gym.make`
- document how to run the environment in human mode

## Testing
- `python -m py_compile mGym_GymRun.py mGym_GymEnv.py mGym_DefSchdRun.py`
- `pip install -q -r requirements.txt` *(fails: Operation cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_6843846b2b30832c83f45581ade0a76a