### PR TITLE
fix: add os import for scheduler fixed allocation

### DIFF
--- a/scheduler.py
+++ b/scheduler.py
@@ -7,6 +7,7 @@ from collections import deque
 import gymnasium as gym
 from gymnasium.spaces import Discrete
 import json
+import os
 
 class DefaultScheduler:
 


### PR DESCRIPTION
## Summary
- fix missing `os` import in scheduler

## Testing
- `python -m py_compile scheduler.py`


------
https://chatgpt.com/codex/tasks/task_e_68438868dbc0832c8c69f9fd013c4061